### PR TITLE
the-stuber: state-management hardening (R6-9 / #27)

### DIFF
--- a/docs/state-management-pattern.md
+++ b/docs/state-management-pattern.md
@@ -1,0 +1,135 @@
+# State management for BotPit bots
+
+If your bot tracks position state locally — stop levels, take-profit prices, breakeven flags, "have I closed this trade yet" — read this. It's a pattern that catches every bot author once.
+
+## The problem
+
+Bots that hold a position need to know things the BotPit API doesn't surface to them on every tick: where the stop is, where the TP is, whether the breakeven trail has been moved, whether the trade is "ours" vs. inherited from a prior process. The natural shape of this is a local in-memory cache — call it `StopMemory` or `PositionState` or whatever fits your language.
+
+That cache has two failure modes that can both leave a position open with no client-side risk management:
+
+1. **Cleared too eagerly.** Your bot sends a CLOSE, gets `status: queued` back, and clears its local state on the assumption that the close will happen. The matching engine then rejects the close (transient feed issue, position-state mismatch, race with another fill) — but your bot already moved on. The position stays open. Your bot's watcher sees `memory.stop_price is None`, returns `None`, never re-emits.
+2. **Never re-hydrated.** Your bot restarts (Railway redeploy, OOM, process crash). On the next tick, the matching engine still reports an open position, but your in-memory state is fresh — no stop, no TP, no entry price. Your bot heartbeats indefinitely with no risk management on a real position.
+
+Both end in the same place: an orphaned position with no automatic exit.
+
+## The rule: observe, don't infer
+
+The fix is one principle, applied in two places:
+
+> **Never derive position state from an API response shape. Always read it from the next snapshot of `snap.open_position`.**
+
+Concretely:
+
+- **Don't clear local state when you *send* a CLOSE.** Clear it when you *observe* `snap.open_position is None`.
+- **Don't trust that local state is hydrated when a position exists.** On every tick, if the snapshot shows a position but your memory has no entry price, install a fallback stop *now*.
+
+The two halves are symmetric. One handles "API response said the close happened but it didn't"; the other handles "process restarted and lost track."
+
+## Drop-in code
+
+This is the pattern in Python; translate to your language. The full version lives in `submissions/the-stuber/bot.py` if you want to read it inline.
+
+### 1. Add a "close was emitted at" timestamp to your local state
+
+```python
+@dataclass
+class StopMemory:
+    stop_price: Optional[float] = None
+    take_profit_price: Optional[float] = None
+    entry_price: Optional[float] = None
+    # ... your other fields ...
+    last_close_emit_at: Optional[float] = None  # epoch seconds; throttles re-emit
+```
+
+This lets you throttle re-emission so you don't spam CLOSE every tick if the engine isn't accepting them.
+
+### 2. Throttle CLOSE re-emission
+
+If a recent CLOSE didn't fill, the watcher will keep wanting to fire on every tick. Stop it from doing so more than once per minute:
+
+```python
+CLOSE_RETRY_THROTTLE_S = 60.0
+
+def watch_stops(snap, mark_price):
+    if snap.open_position is None:
+        return None
+    if memory.last_close_emit_at is not None:
+        if time.time() - memory.last_close_emit_at < CLOSE_RETRY_THROTTLE_S:
+            return None
+    # ... rest of stop/TP check logic ...
+```
+
+### 3. When sending CLOSE, only update the timestamp — don't clear state
+
+```python
+def apply_decision(api, decision, snap, pair):
+    if decision.action == Action.CLOSE:
+        if snap.open_position is None:
+            return
+        resp = api.send_signal(side="close", pair=pair, size_pct=100, leverage=1)
+        log.info("CLOSE sent -> %s", resp.get("status"))
+        # Mark the emit time so the throttle works,
+        # but don't clear stop/tp/entry — those get cleared in the run loop
+        # only when we observe the position is actually flat.
+        memory.last_close_emit_at = time.time()
+```
+
+### 4. Confirmed-flat clear and orphan recovery on every tick
+
+In your main loop, right after building the snapshot:
+
+```python
+ORPHAN_FALLBACK_STOP_PCT = 1.5
+ORPHAN_FALLBACK_TP_PCT = 3.0
+
+while True:
+    snap = build_snapshot(api, PAIR, rules)
+    mark = get_mark_price(PAIR)
+
+    # Confirmed-flat clear: position is verifiably gone, safe to wipe memory.
+    if snap.open_position is None and memory.entry_price is not None:
+        log.info("position confirmed closed — clearing local stop memory")
+        memory.stop_price = None
+        memory.take_profit_price = None
+        memory.entry_price = None
+        memory.last_close_emit_at = None
+        # ... clear your other fields ...
+
+    # Orphan recovery: position exists but bot has no stop tracking.
+    # Install a conservative fallback stop so the position is never silently un-watched.
+    if snap.open_position is not None and memory.entry_price is None:
+        entry = float(snap.open_position["entry_price"])
+        side = snap.open_position["side"]
+        if side == "long":
+            memory.stop_price = entry * (1 - ORPHAN_FALLBACK_STOP_PCT / 100)
+            memory.take_profit_price = entry * (1 + ORPHAN_FALLBACK_TP_PCT / 100)
+        else:
+            memory.stop_price = entry * (1 + ORPHAN_FALLBACK_STOP_PCT / 100)
+            memory.take_profit_price = entry * (1 - ORPHAN_FALLBACK_TP_PCT / 100)
+        memory.entry_price = entry
+        log.warning("orphan position detected — installed fallback stop @ %.2f, tp @ %.2f",
+                    memory.stop_price, memory.take_profit_price)
+
+    # ... rest of your loop: watcher, decide(), apply ...
+```
+
+## Picking your fallback stop levels
+
+The orphan-recovery fallback is intentionally conservative — it's protecting an already-orphaned position, not implementing your strategy. Pick numbers that get you out without thinking too hard about price action:
+
+- **1.5% from entry** is a reasonable default for major pairs (BTC, ETH). It's tight enough that an orphan installed during normal volatility will exit promptly; loose enough that a normal mid-trade restart won't immediately stop you out.
+- For higher-volatility pairs (memecoins, low-liquidity perps), bump to 3%.
+- For lower-volatility (gold, indices), drop to 0.75%.
+
+Re-tune per your own strategy's risk profile. Don't try to recover the original stop level from API data — you usually can't, and a wrong fallback is worse than a generic conservative one.
+
+## What this pattern doesn't fix
+
+- **Strategy bugs that emit CLOSE against positions that don't exist.** That's the inverse failure class — your `decide()` logic thinks it has a position when the engine sees flat. Fix: read `snap.open_position` *before* deciding to close, and reset your internal state when it disagrees with the engine.
+- **Engine-side queue or feed problems.** If BotPit's matching engine is rejecting your closes for `PRICE_FEED_STALE` or queueing them indefinitely, this pattern keeps your bot's local state honest, but it doesn't make the engine fill the trade. Surface that to BotPit as an issue.
+
+## Related issues
+
+- [#27 (R6-9)](https://github.com/Botpit-io/botpit-bot-starter/issues/27) — the discovery: optimistic state-clear + price feed outage = orphaned position
+- [#12 (R4-1)](https://github.com/Botpit-io/botpit-bot-starter/issues/12) — partial-close support (separate from this pattern, but related risk-management surface)

--- a/submissions/the-stuber/bot.py
+++ b/submissions/the-stuber/bot.py
@@ -97,9 +97,15 @@ class StopMemory:
     original_stop_pct: Optional[float] = None
     moved_to_breakeven: bool = False
     last_close_reason: Optional[str] = None  # set by watcher, read by apply_decision for log_decision
+    last_close_emit_at: Optional[float] = None  # epoch seconds; throttles CLOSE re-emit (R6-9)
 
 
 memory = StopMemory()
+
+# R6-9 hardening constants.
+CLOSE_RETRY_THROTTLE_S = 60.0       # don't re-emit CLOSE more than once per minute
+ORPHAN_FALLBACK_STOP_PCT = 1.5      # conservative stop installed for orphaned positions
+ORPHAN_FALLBACK_TP_PCT = 3.0
 
 
 # ---------- Candle cache (Binance public klines) ----------
@@ -616,6 +622,12 @@ def get_mark_price(pair: str) -> float:
 def watch_stops(snap: Snapshot, mark_price: float) -> Optional[Decision]:
     if snap.open_position is None:
         return None
+    # R6-9 throttle: don't re-emit CLOSE more than once per CLOSE_RETRY_THROTTLE_S.
+    # If a recent CLOSE didn't fill (queued forever bug), the watcher would
+    # otherwise spam CLOSEs every tick.
+    if memory.last_close_emit_at is not None:
+        if time.time() - memory.last_close_emit_at < CLOSE_RETRY_THROTTLE_S:
+            return None
     side = snap.open_position["side"]
     if memory.stop_price is not None:
         if side == "long" and mark_price <= memory.stop_price:
@@ -705,14 +717,14 @@ def apply_decision(api: BotPit, decision: Decision, snap: Snapshot, pair: str) -
                 reason=close_reason[:280],
                 payload={"pair": pair, "side_closed": snap.open_position.get("side"),
                          "entry": memory.entry_price,
-                         "moved_to_breakeven": memory.moved_to_breakeven},
+                         "moved_to_breakeven": memory.moved_to_breakeven,
+                         "close_status": resp.get("status")},
             )
-        memory.stop_price = None
-        memory.take_profit_price = None
-        memory.entry_price = None
-        memory.original_stop_pct = None
-        memory.moved_to_breakeven = False
-        memory.last_close_reason = None
+        # R6-9: do NOT clear stop/tp/entry here. The matching engine has been
+        # observed returning `queued` indefinitely without ever filling the
+        # close. Memory is cleared only when build_snapshot() reports the
+        # position is verifiably closed — see the run() loop.
+        memory.last_close_emit_at = time.time()
 
 
 def run() -> None:
@@ -743,6 +755,42 @@ def run() -> None:
         try:
             snap = build_snapshot(api, PAIR, rules)
             mark = get_mark_price(PAIR)
+
+            # R6-9: confirmed-flat clear. Position is verifiably gone, safe to wipe
+            # memory. Replaces the optimistic clear that used to live in
+            # apply_decision()'s CLOSE branch.
+            if snap.open_position is None and memory.entry_price is not None:
+                log.info("position confirmed closed — clearing local stop memory")
+                memory.stop_price = None
+                memory.take_profit_price = None
+                memory.entry_price = None
+                memory.original_stop_pct = None
+                memory.moved_to_breakeven = False
+                memory.last_close_reason = None
+                memory.last_close_emit_at = None
+
+            # R6-9: orphan recovery. Position exists but bot has no stop tracking
+            # — happens after restart, or after a CLOSE was emitted but the
+            # matching engine never filled it. Install a conservative fallback
+            # stop so the position is never silently un-watched.
+            if snap.open_position is not None and memory.entry_price is None:
+                entry = float(snap.open_position["entry_price"])
+                side = snap.open_position["side"]
+                if side == "long":
+                    memory.stop_price = entry * (1 - ORPHAN_FALLBACK_STOP_PCT / 100)
+                    memory.take_profit_price = entry * (1 + ORPHAN_FALLBACK_TP_PCT / 100)
+                else:
+                    memory.stop_price = entry * (1 + ORPHAN_FALLBACK_STOP_PCT / 100)
+                    memory.take_profit_price = entry * (1 - ORPHAN_FALLBACK_TP_PCT / 100)
+                memory.entry_price = entry
+                memory.original_stop_pct = ORPHAN_FALLBACK_STOP_PCT
+                memory.moved_to_breakeven = False
+                log.warning(
+                    "orphan position detected (%s %.4f @ %.2f) — installed fallback stop @ %.2f, tp @ %.2f",
+                    side, snap.open_position.get("size_units", 0.0), entry,
+                    memory.stop_price, memory.take_profit_price,
+                )
+
             stop_decision = watch_stops(snap, mark)
             if stop_decision:
                 apply_decision(api, stop_decision, snap, PAIR)


### PR DESCRIPTION
Applies the Stuber-side patch from [#27](https://github.com/Botpit-io/botpit-bot-starter/issues/27) verbatim — the diff Stuber-side Claude posted in [comment 4405517893](https://github.com/Botpit-io/botpit-bot-starter/issues/27#issuecomment-4405517893) for BotPit-side to apply per role boundary.

## Two artifacts

**`submissions/the-stuber/bot.py`** — three logical changes (+55 / -7 lines):
- `StopMemory.last_close_emit_at` field + 60s throttle in `watch_stops()` — bot whose CLOSE didn't fill no longer spams re-emits every tick
- `apply_decision()` CLOSE branch no longer clears stop/tp/entry on emit; only sets `last_close_emit_at`
- `run()` loop adds two on-tick checks:
  - **Confirmed-flat clear** — wipe memory only when `snap.open_position` is verifiably None
  - **Orphan recovery** — if a position exists but bot has no memory of it, install a 1.5% / 3% TP fallback stop so the position is never silently un-watched

One rule, three places: *the bot's local state mirrors observed engine state, never inferred state.*

**\`docs/state-management-pattern.md\`** (new) — the R6-10 educational doc Stuber-side committed to writing. Generic pattern any bot author can use; references R6-9 (#27) and R4-1 (#12).

## Sequencing context

Per the (A) sequencing in #27 — backfill of the orphaned position settled platform-side at 2026-05-08 ~09:43 UTC ([commit 9437c41 on agent-arena](https://github.com/leadballoon-agency/agent-arena/commit/9437c41)). Bot is currently flat. This patch picks up the new behaviour on next deploy; the failure mode #27 describes is closed end-to-end once Railway redeploys.

## Engineering fix on platform side

The matching of this patch is the BotPit-side three-phase engineering fix landed on \`main\` in agent-arena:
- [\`26cc462\`](https://github.com/leadballoon-agency/agent-arena/commit/26cc462) Phase 1 — auto-retry on transient rejections
- [\`25b4f95\`](https://github.com/leadballoon-agency/agent-arena/commit/25b4f95) Phase 2 — sync POST + GET /api/v1/signals/:id
- [\`17d9323\`](https://github.com/leadballoon-agency/agent-arena/commit/17d9323) Phase 3 — DELETE /api/v1/signals/:id soft-cancel

Defence in depth: platform-side prevents short-window stale events from orphaning a trade; bot-side handles whatever the platform misses.

Refs Botpit-io/botpit-bot-starter#27 · leadballoon-agency/agent-arena#3

🤖 Generated with [Claude Code](https://claude.com/claude-code)