### PR TITLE
The Stuber: news-flat macro blackout (uses /api/v1/tv/state macro_calendar)

### DIFF
--- a/submissions/the-stuber/STRATEGY.md
+++ b/submissions/the-stuber/STRATEGY.md
@@ -15,19 +15,25 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 ## Pair / timeframe
 
 - **Pair:** BTC-USDT (Binance perpetual mark prices)
-- **Timeframe:** 5m candles
-- **Cadence:** 10s polling on state + mark price; 60s candle refresh from Binance public klines
+- **Timeframe:** 15m candles (raised from 5m for chop tolerance; `BOTPIT_TIMEFRAME`)
+- **Higher timeframe:** 4h, used by the trend-of-trend filter (R6-3)
+- **Cadence:** 10s polling on state + mark price; 60s candle refresh from Binance public klines (4h candles refreshed every 5 min)
 
 ## Entry conditions
 
 **Long:**
 
-1. Most recent fractal pivot high (N=5 lookback each side) is *higher* than the prior fractal pivot high → bullish structure break confirmed.
+1. Most recent fractal pivot high (N=10 lookback each side; `STUBER_PIVOT_N`) is *higher* than the prior fractal pivot high → bullish structure break confirmed.
 2. Find the lowest low between those two pivot highs → "origin low".
 3. Compute fib retracement of (origin low → higher high).
 4. If current mark is in 0.618–0.786 retracement zone → enter long.
 
 **Short:** mirror. Pivot low < prior pivot low, find highest high between them, fib retracement up from lower low.
+
+**Filters applied before any entry:**
+
+- **Trend-of-trend (R6-3):** compute the most recent confirmed structure event on the 4h chart. Skip 15m longs while the 4h structure is bearish, and 15m shorts while it's bullish. A "neutral" 4h (no confirmed break) allows either side.
+- **News-flat:** if `/api/v1/tv/state`'s `macro_calendar.next` shows a high-impact US release (CPI/NFP/FOMC/…) within `STUBER_MACRO_BUFFER_MIN` minutes (default 30), decline new entries — and close any *existing* position — until the print is past. Standard prop-firm "no trading around scheduled news" rule; set the buffer to `0` to disable.
 
 ## Risk + sizing
 
@@ -44,7 +50,7 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 - **Tight stops at structure invalidation** keep individual losses ≤ 3% of equity per trade.
 - **Breakeven trail** caps drawdown contribution from any trade that moves 1R in our favor — it can no longer turn into a loss.
 - **No averaging-down or pyramiding** — the matcher rejects same-side adds anyway.
-- **Conservative leverage by default** — typical 5m structure-break stop distances (~1–2%) require 1–3× leverage at 3% risk, well below the 20× cap that ruins most retail bots.
+- **Conservative leverage by default** — typical 15m structure-break stop distances (~1–2%) require 1–3× leverage at 3% risk, well below the 20× cap that ruins most retail bots.
 - **Pair selection (BTC):** deepest liquidity, lowest mark-price slippage of the available pairs.
 
 ## Known weaknesses
@@ -52,9 +58,9 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 - **Chop kills it.** Sideways markets generate false structure breaks and pullbacks that don't bounce. Expect long stretches of small losses in low-trend regimes.
 - **Trend continuation that doesn't pull back** is missed entirely. An aggressive bullish move that runs from the structure break to the 1.272 extension without revisiting the 0.618 zone gives The Stuber zero edge.
 - **Fixed fib zone (0.618–0.786) is an oversimplification.** Real discretionary traders weigh confluence (other levels, volume profile, session timing). The Stuber doesn't.
-- **No regime filter.** Should arguably skip trades during low-volatility hours or around macro events. Doesn't.
-- **Mark-price-based entry timing** means the bot may enter slightly off the candle close — fine for 5m, less ideal for 1m.
-- **Fractal pivot detection has natural lookahead delay.** A pivot needs N=5 candles after it to confirm — so structure breaks confirm with a 25-minute lag on 5m. This is honest, not a bug, but it means we're never earliest into a move.
+- **Partial regime awareness only.** A 4h trend-of-trend filter (R6-3) suppresses entries that disagree with the higher-timeframe structure, and the bot now goes news-flat ahead of scheduled high-impact macro prints (CPI/NFP/FOMC) via `/api/v1/tv/state`'s `macro_calendar`. Still no low-volatility-hours filter, and no notion of *unscheduled* shocks.
+- **Mark-price-based entry timing** means the bot may enter slightly off the candle close — fine for 15m, less ideal for sub-5m.
+- **Fractal pivot detection has natural lookahead delay.** A pivot needs N=10 candles after it to confirm — so on 15m, structure breaks confirm ~2.5h after the pivot. The 4h trend filter adds further lag of its own. This is honest, not a bug, but it means we're never earliest into a move; the bet is on the *quality* of confirmed setups, not speed.
 - **Single pair, single direction.** No diversification across BTC/ETH/SOL/PAXG; no hedging.
 - **Breakeven trail is a substitute for true scale-out** — see [R4-1](https://github.com/Botpit-io/botpit-bot-starter/issues/12). Real scale-out (close 50% at 1R, runner stays with stop at BE) would lock in *realized* profit at the partial-close price, which the breakeven trail doesn't. When R4-1 ships, this is a trivial upgrade.
 
@@ -70,12 +76,14 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 | Parameter | Value |
 |---|---|
 | Pair | BTC-USDT |
-| Timeframe | 5m |
+| Timeframe | 15m (was 5m) |
 | Risk per trade | 3% of equity |
 | Stop placement | Origin low (long) / origin high (short) |
 | Take profit | 1.272 fib extension |
 | Breakeven trail trigger | Mark moves ≥ 1R in favor |
-| Pivot lookback (N) | 5 candles each side |
+| Pivot lookback (N) | 10 candles each side (was 5) |
 | Fib entry zone | 0.618 to 0.786 retracement |
+| Higher-TF trend filter | 4h trend-of-trend; skip entries against it (R6-3) |
+| Macro blackout | News-flat within 30 min of a high-impact print (`STUBER_MACRO_BUFFER_MIN`, 0=off) |
 | Max leverage | 20× (platform cap; typically 1–3× used) |
 | Min trade-size policy | Skip if stop too tight to size within 20× leverage |

--- a/submissions/the-stuber/bot.py
+++ b/submissions/the-stuber/bot.py
@@ -4,6 +4,8 @@ The Stuber — Fibonacci pullback after structure break.
 Strategy: long/short entries on pullback into the 0.618-0.786 fib zone after
 a confirmed market-structure break. Stop at origin low/high, TP at 1.272
 extension. Risk-based sizing for 3% loss on stop. Breakeven trail at 1R.
+4h trend-of-trend filter (R6-3). News-flat ahead of scheduled high-impact
+macro prints via /api/v1/tv/state's macro_calendar.
 
 Built on the BotPit code-bot starter (HMAC path).
 See STRATEGY.md for the full thesis + weaknesses.
@@ -31,11 +33,11 @@ API_BASE = os.getenv("BOTPIT_API_BASE", "https://www.botpit.io")
 PUBKEY = os.environ.get("BOTPIT_AGENT_PUBKEY")
 SECRET = os.environ.get("BOTPIT_AGENT_SECRET")
 PAIR = os.getenv("BOTPIT_PAIR", "BTC-USDT")
-TIMEFRAME = os.getenv("BOTPIT_TIMEFRAME", "5m")
+TIMEFRAME = os.getenv("BOTPIT_TIMEFRAME", "15m")  # raised from 5m for chop tolerance
 TICK_SECONDS = int(os.getenv("BOTPIT_TICK_SECONDS", "10"))
 
 # Strategy params (tweak via env if needed)
-PIVOT_LOOKBACK = int(os.getenv("STUBER_PIVOT_N", "5"))
+PIVOT_LOOKBACK = int(os.getenv("STUBER_PIVOT_N", "10"))  # raised from 5 for chop tolerance
 FIB_ZONE_LOW = float(os.getenv("STUBER_FIB_LOW", "0.618"))
 FIB_ZONE_HIGH = float(os.getenv("STUBER_FIB_HIGH", "0.786"))
 FIB_TP_EXTENSION = float(os.getenv("STUBER_TP_EXT", "1.272"))
@@ -50,6 +52,15 @@ CANDLE_REFRESH_SECONDS = int(os.getenv("STUBER_CANDLE_REFRESH", "60"))
 HTF_TIMEFRAME = os.getenv("STUBER_HTF_TIMEFRAME", "4h")
 HTF_PIVOT_N = int(os.getenv("STUBER_HTF_PIVOT_N", "5"))
 HTF_CANDLE_REFRESH_SECONDS = int(os.getenv("STUBER_HTF_CANDLE_REFRESH", "300"))  # 5 min
+
+# Macro-event blackout — go news-flat ahead of scheduled high-impact US prints
+# (CPI / NFP / FOMC / …). The economic calendar is served in /api/v1/tv/state as
+# `macro_calendar` (`.next` = soonest high-impact release with name / at / in_minutes).
+# When the next print is within this many minutes: close any open position and
+# decline new entries until the print is out of the way (in_minutes goes negative).
+# Standard prop-firm "no trading around scheduled news" rule; Prop Firm Pete uses 30.
+# Set STUBER_MACRO_BUFFER_MIN=0 to disable.
+MACRO_FLAT_BUFFER_MINUTES = float(os.getenv("STUBER_MACRO_BUFFER_MIN", "30"))
 
 logging.basicConfig(format="[%(asctime)s] %(message)s", datefmt="%H:%M:%S", level=logging.INFO)
 log = logging.getLogger("the-stuber")
@@ -81,6 +92,7 @@ class Snapshot:
     open_position: Optional[Dict[str, Any]]
     last_fill_price: Optional[float]
     pair_config: Dict[str, Any]
+    macro_calendar: Optional[Dict[str, Any]] = None  # /api/v1/tv/state `macro_calendar` block, if present
 
 
 @dataclass
@@ -342,6 +354,33 @@ def _size_for_risk(
     return None
 
 
+# ---------- Macro-event blackout (news-flat) ----------
+
+def _macro_blackout(snap: "Snapshot") -> Optional[Tuple[str, float]]:
+    """If a scheduled high-impact release is within MACRO_FLAT_BUFFER_MINUTES
+    and hasn't happened yet, return (event_name, minutes_until). Otherwise None.
+
+    Reads `macro_calendar.next` from /api/v1/tv/state — tolerant of the block
+    being absent (older state payloads) or `next` being null. Once the print is
+    past, `in_minutes` goes negative and trading resumes."""
+    if MACRO_FLAT_BUFFER_MINUTES <= 0:
+        return None
+    cal = snap.macro_calendar
+    if not cal:
+        return None
+    nxt = cal.get("next")
+    if not nxt:
+        return None
+    mins = nxt.get("in_minutes")
+    try:
+        mins = float(mins)
+    except (TypeError, ValueError):
+        return None
+    if 0.0 <= mins < MACRO_FLAT_BUFFER_MINUTES:
+        return str(nxt.get("name") or "high-impact release"), mins
+    return None
+
+
 # ---------- The Stuber strategy ----------
 
 def decide(snap: Snapshot, mark_price: float) -> Decision:
@@ -384,6 +423,17 @@ def _decide_inner(snap: Snapshot, mark_price: float) -> Decision:
     if snap.open_position is not None:
         side = snap.open_position.get("side", "?")
         return _hold(f"managing:{side}", f"managing open {side} position")
+
+    # News-flat: don't open into a scheduled high-impact print (the watcher
+    # handles closing any *existing* position — see watch_stops()).
+    blackout = _macro_blackout(snap)
+    if blackout is not None:
+        name, mins = blackout
+        return _hold(
+            f"news-flat:{name}",
+            f"news-flat — {name} in {mins:.0f}m (≤ {MACRO_FLAT_BUFFER_MINUTES:.0f}m buffer); "
+            f"declining new entries until the print is out of the way",
+        )
 
     candles = _get_candles(PAIR)
     if len(candles) < 2 * PIVOT_LOOKBACK + 2:
@@ -629,6 +679,17 @@ def watch_stops(snap: Snapshot, mark_price: float) -> Optional[Decision]:
         if time.time() - memory.last_close_emit_at < CLOSE_RETRY_THROTTLE_S:
             return None
     side = snap.open_position["side"]
+    # News-flat: flatten ahead of a scheduled high-impact print, regardless of stop/TP.
+    # Standard prop-firm rule — don't leave a leveraged position orphaned across an
+    # event you didn't see coming ("the 37 minutes that weren't there").
+    blackout = _macro_blackout(snap)
+    if blackout is not None:
+        name, mins = blackout
+        reason = (f"news-flat close ({side}) — {name} in {mins:.0f}m "
+                  f"(≤ {MACRO_FLAT_BUFFER_MINUTES:.0f}m buffer); flat is flat")
+        log.info(reason)
+        memory.last_close_reason = reason
+        return Decision(Action.CLOSE)
     if memory.stop_price is not None:
         if side == "long" and mark_price <= memory.stop_price:
             reason = (
@@ -678,6 +739,7 @@ def build_snapshot(api: BotPit, pair: str, rules: dict) -> Snapshot:
         open_position=open_pos,
         last_fill_price=last_fill_price,
         pair_config=rules,
+        macro_calendar=s.get("macro_calendar"),
     )
 
 


### PR DESCRIPTION
## What

Wires **The Stuber** to the economic calendar now exposed in `GET /api/v1/tv/state` as `macro_calendar` (`.next` = soonest high-impact US release — CPI/NFP/FOMC/… — with `name`, `at`, `in_minutes`).

Standard prop-firm "no trading around scheduled news" rule — the one that would've saved the bot in "the 37 minutes that weren't there." The Stuber's the highest-rated bot on the board, so it has the most to lose to a leveraged position orphaned across a print.

## Behaviour

New env var **`STUBER_MACRO_BUFFER_MIN`** — default **30**, set `0` to disable. When the next high-impact release is within the buffer:

- `watch_stops()` emits `CLOSE` to flatten any open position ("news-flat close (long) — US CPI in 12m … flat is flat")
- `decide()` declines new entries and records the reason via `log_decision()`
- resumes automatically once the print is past (`in_minutes` goes negative)

Respects the existing R6-9 CLOSE throttle and confirmed-flat memory clear. Tolerant of the `macro_calendar` block being absent / `next` being null (older state payloads) — feature is simply inert in that case.

## Also in this PR — STRATEGY.md brought inline

The doc had drifted from the deployed config. Fixed:
- timeframe **15m** (was 5m), pivot **N=10** (was 5) — matches Railway env; `bot.py` code defaults bumped to match
- documents the **4h trend-of-trend filter (R6-3)**, which wasn't mentioned at all
- documents the new news-flat filter; downgraded the "no regime filter" weakness accordingly

## Testing

`python3 -m py_compile` clean. Smoke-tested: `_macro_blackout()` detection (in-window / out-of-window / print-past / missing block / null `next` / missing name), `decide()` HOLDs inside the window, `watch_stops()` emits `CLOSE` inside the window.

No new auth, no new dependency. Needs no Railway change to take effect (default buffer 30).

🤖 Generated with [Claude Code](https://claude.com/claude-code)