### PR TITLE
The Stuber: Bybit fallback for market data (resilience, R6-16)

### DIFF
--- a/submissions/the-stuber/STRATEGY.md
+++ b/submissions/the-stuber/STRATEGY.md
@@ -17,7 +17,8 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 - **Pair:** BTC-USDT (Binance perpetual mark prices)
 - **Timeframe:** 15m candles (raised from 5m for chop tolerance; `BOTPIT_TIMEFRAME`)
 - **Higher timeframe:** 4h, used by the trend-of-trend filter (R6-3)
-- **Cadence:** 10s polling on state + mark price; 60s candle refresh from Binance public klines (4h candles refreshed every 5 min)
+- **Cadence:** 10s polling on state + mark price; 60s candle refresh (4h candles every 5 min)
+- **Market data:** Binance USDⓈ-M futures primary, Bybit linear perps fallback — a single-venue IP ban (e.g. Binance 418 on a shared PaaS egress IP) doesn't take the bot offline (R6-16)
 
 ## Entry conditions
 

--- a/submissions/the-stuber/STRATEGY.md
+++ b/submissions/the-stuber/STRATEGY.md
@@ -18,7 +18,7 @@ This isn't a novel edge — it's a well-known one. The Stuber's bet is that *sys
 - **Timeframe:** 15m candles (raised from 5m for chop tolerance; `BOTPIT_TIMEFRAME`)
 - **Higher timeframe:** 4h, used by the trend-of-trend filter (R6-3)
 - **Cadence:** 10s polling on state + mark price; 60s candle refresh (4h candles every 5 min)
-- **Market data:** Binance USDⓈ-M futures primary, Bybit linear perps fallback — a single-venue IP ban (e.g. Binance 418 on a shared PaaS egress IP) doesn't take the bot offline (R6-16)
+- **Market data:** Binance USDⓈ-M futures primary → FMP crypto feed (if `STUBER_FMP_KEY` set) → Bybit linear perps — three independent IP-reputation surfaces, so a single-venue ban (e.g. Binance `418` on a shared PaaS egress IP) doesn't take the bot offline (R6-16)
 
 ## Entry conditions
 

--- a/submissions/the-stuber/bot.py
+++ b/submissions/the-stuber/bot.py
@@ -13,6 +13,7 @@ See STRATEGY.md for the full thesis + weaknesses.
 
 from __future__ import annotations
 
+import calendar
 import enum
 import hashlib
 import hmac
@@ -120,19 +121,28 @@ ORPHAN_FALLBACK_STOP_PCT = 1.5      # conservative stop installed for orphaned p
 ORPHAN_FALLBACK_TP_PCT = 3.0
 
 
-# ---------- Market data (Binance primary, Bybit fallback) ----------
+# ---------- Market data (Binance primary, FMP + Bybit fallbacks) ----------
 #
 # Both candles and the mark price come from a single venue by default — and on a
 # shared-NAT PaaS (Railway/Render/Fly/…) the egress IP's reputation with that
 # venue is outside our control: another tenant hammering the same IP gets it
-# 418'd by Binance, and we inherit the ban (cf. R6-16). So: try Binance first,
-# fall back to Bybit linear perps (no API key, different IP-rep surface). If both
-# fail, the callers' existing behaviour stands (candles → cache, mark → retry).
+# 418'd by Binance, and we inherit the ban (cf. R6-16). So we chain sources,
+# each on an independent IP-rep surface:
+#   1. Binance USDⓈ-M futures  — primary; the right number (perp mark price), free
+#   2. FMP crypto feed         — used iff STUBER_FMP_KEY is set; paid → reliable;
+#                                aggregated spot, so a small basis vs. perp mark —
+#                                fine for a degraded fallback
+#   3. Bybit linear perps      — last resort; free, no key
+# If all configured sources fail, callers' existing behaviour stands
+# (candles → cache, mark → run() retry loop).
 
 BINANCE_KLINES = "https://fapi.binance.com/fapi/v1/klines"
 BINANCE_MARK = "https://fapi.binance.com/fapi/v1/premiumIndex"
 BYBIT_KLINES = "https://api.bybit.com/v5/market/kline"
 BYBIT_TICKERS = "https://api.bybit.com/v5/market/tickers"
+FMP_QUOTE = "https://financialmodelingprep.com/api/v3/quote"
+FMP_CHART = "https://financialmodelingprep.com/api/v3/historical-chart"
+FMP_API_KEY = os.getenv("STUBER_FMP_KEY", "").strip()  # optional; financialmodelingprep.com
 
 # Binance interval string -> Bybit v5 interval code.
 _BYBIT_INTERVAL = {
@@ -140,6 +150,16 @@ _BYBIT_INTERVAL = {
     "1h": "60", "2h": "120", "4h": "240", "6h": "360", "12h": "720",
     "1d": "D", "1w": "W", "1M": "M",
 }
+# Binance interval string -> FMP historical-chart interval slug (intraday only).
+_FMP_INTERVAL = {
+    "1m": "1min", "5m": "5min", "15m": "15min", "30m": "30min",
+    "1h": "1hour", "4h": "4hour",
+}
+
+
+def _fmp_symbol(pair: str) -> str:
+    """BotPit pair (e.g. BTC-USDT) -> FMP crypto symbol (e.g. BTCUSD)."""
+    return pair.split("-")[0].upper() + "USD"
 
 
 @dataclass
@@ -200,12 +220,44 @@ def _fetch_candles_bybit(pair: str, timeframe: str, limit: int) -> List[Candle]:
     return candles
 
 
+def _fetch_candles_fmp(pair: str, timeframe: str, limit: int) -> List[Candle]:
+    if not FMP_API_KEY:
+        raise RuntimeError("no FMP API key configured (set STUBER_FMP_KEY)")
+    interval = _FMP_INTERVAL.get(timeframe)
+    if interval is None:
+        raise ValueError(f"no FMP interval mapping for timeframe {timeframe!r}")
+    r = requests.get(
+        f"{FMP_CHART}/{interval}/{_fmp_symbol(pair)}",
+        params={"apikey": FMP_API_KEY},
+        timeout=5,
+    )
+    r.raise_for_status()
+    rows = r.json()  # newest-first: [{"date","open","low","high","close","volume"}, ...]
+    if not isinstance(rows, list) or not rows:
+        raise RuntimeError(f"FMP chart: no data for {_fmp_symbol(pair)} {interval}")
+    candles: List[Candle] = []
+    for k in rows[:limit]:
+        try:
+            ot = int(calendar.timegm(time.strptime(k["date"], "%Y-%m-%d %H:%M:%S")) * 1000)
+        except (KeyError, ValueError, TypeError):
+            ot = 0
+        candles.append(Candle(open_time=ot, open=float(k["open"]), high=float(k["high"]),
+                              low=float(k["low"]), close=float(k["close"])))
+    candles.reverse()  # oldest-first, to match Binance ordering
+    return candles
+
+
 def _fetch_candles(pair: str, timeframe: str, limit: int) -> List[Candle]:
     try:
         return _fetch_candles_binance(pair, timeframe, limit)
     except Exception as e:
-        log.warning("Binance klines failed (%s) — falling back to Bybit", e)
-        return _fetch_candles_bybit(pair, timeframe, limit)
+        log.warning("Binance klines failed (%s) — trying next source", e)
+    if FMP_API_KEY:
+        try:
+            return _fetch_candles_fmp(pair, timeframe, limit)
+        except Exception as e:
+            log.warning("FMP klines failed (%s) — trying Bybit", e)
+    return _fetch_candles_bybit(pair, timeframe, limit)
 
 
 def _get_candles(pair: str, timeframe: str = TIMEFRAME) -> List[Candle]:
@@ -730,12 +782,31 @@ def _mark_bybit(pair: str) -> float:
     return float(t.get("markPrice") or t["lastPrice"])
 
 
+def _mark_fmp(pair: str) -> float:
+    if not FMP_API_KEY:
+        raise RuntimeError("no FMP API key configured (set STUBER_FMP_KEY)")
+    r = requests.get(f"{FMP_QUOTE}/{_fmp_symbol(pair)}", params={"apikey": FMP_API_KEY}, timeout=5)
+    r.raise_for_status()
+    data = r.json()
+    if not isinstance(data, list) or not data:
+        raise RuntimeError(f"FMP quote: no data for {_fmp_symbol(pair)}")
+    px = data[0].get("price")
+    if px is None:
+        raise RuntimeError(f"FMP quote: no price field for {_fmp_symbol(pair)}")
+    return float(px)
+
+
 def get_mark_price(pair: str) -> float:
     try:
         return _mark_binance(pair)
     except Exception as e:
-        log.warning("Binance mark price failed (%s) — falling back to Bybit", e)
-        return _mark_bybit(pair)
+        log.warning("Binance mark price failed (%s) — trying next source", e)
+    if FMP_API_KEY:
+        try:
+            return _mark_fmp(pair)
+        except Exception as e:
+            log.warning("FMP mark price failed (%s) — trying Bybit", e)
+    return _mark_bybit(pair)
 
 
 def watch_stops(snap: Snapshot, mark_price: float) -> Optional[Decision]:

--- a/submissions/the-stuber/bot.py
+++ b/submissions/the-stuber/bot.py
@@ -120,9 +120,26 @@ ORPHAN_FALLBACK_STOP_PCT = 1.5      # conservative stop installed for orphaned p
 ORPHAN_FALLBACK_TP_PCT = 3.0
 
 
-# ---------- Candle cache (Binance public klines) ----------
+# ---------- Market data (Binance primary, Bybit fallback) ----------
+#
+# Both candles and the mark price come from a single venue by default — and on a
+# shared-NAT PaaS (Railway/Render/Fly/…) the egress IP's reputation with that
+# venue is outside our control: another tenant hammering the same IP gets it
+# 418'd by Binance, and we inherit the ban (cf. R6-16). So: try Binance first,
+# fall back to Bybit linear perps (no API key, different IP-rep surface). If both
+# fail, the callers' existing behaviour stands (candles → cache, mark → retry).
 
 BINANCE_KLINES = "https://fapi.binance.com/fapi/v1/klines"
+BINANCE_MARK = "https://fapi.binance.com/fapi/v1/premiumIndex"
+BYBIT_KLINES = "https://api.bybit.com/v5/market/kline"
+BYBIT_TICKERS = "https://api.bybit.com/v5/market/tickers"
+
+# Binance interval string -> Bybit v5 interval code.
+_BYBIT_INTERVAL = {
+    "1m": "1", "3m": "3", "5m": "5", "15m": "15", "30m": "30",
+    "1h": "60", "2h": "120", "4h": "240", "6h": "360", "12h": "720",
+    "1d": "D", "1w": "W", "1M": "M",
+}
 
 
 @dataclass
@@ -138,7 +155,7 @@ _candle_cache: List[Candle] = []
 _candle_cache_at: float = 0.0
 
 
-def _fetch_candles(pair: str, timeframe: str, limit: int) -> List[Candle]:
+def _fetch_candles_binance(pair: str, timeframe: str, limit: int) -> List[Candle]:
     symbol = pair.replace("-", "")
     r = requests.get(
         BINANCE_KLINES,
@@ -156,6 +173,39 @@ def _fetch_candles(pair: str, timeframe: str, limit: int) -> List[Candle]:
         )
         for k in r.json()
     ]
+
+
+def _fetch_candles_bybit(pair: str, timeframe: str, limit: int) -> List[Candle]:
+    symbol = pair.replace("-", "")
+    interval = _BYBIT_INTERVAL.get(timeframe)
+    if interval is None:
+        raise ValueError(f"no Bybit interval mapping for timeframe {timeframe!r}")
+    r = requests.get(
+        BYBIT_KLINES,
+        params={"category": "linear", "symbol": symbol,
+                "interval": interval, "limit": min(limit, 1000)},
+        timeout=5,
+    )
+    r.raise_for_status()
+    data = r.json()
+    if data.get("retCode") != 0:
+        raise RuntimeError(f"Bybit kline error {data.get('retCode')}: {data.get('retMsg')}")
+    rows = data["result"]["list"]  # Bybit returns newest-first: [start, o, h, l, c, vol, turnover]
+    candles = [
+        Candle(open_time=int(k[0]), open=float(k[1]), high=float(k[2]),
+               low=float(k[3]), close=float(k[4]))
+        for k in rows
+    ]
+    candles.reverse()  # oldest-first, to match Binance ordering
+    return candles
+
+
+def _fetch_candles(pair: str, timeframe: str, limit: int) -> List[Candle]:
+    try:
+        return _fetch_candles_binance(pair, timeframe, limit)
+    except Exception as e:
+        log.warning("Binance klines failed (%s) — falling back to Bybit", e)
+        return _fetch_candles_bybit(pair, timeframe, limit)
 
 
 def _get_candles(pair: str, timeframe: str = TIMEFRAME) -> List[Candle]:
@@ -659,14 +709,33 @@ class BotPit:
 _api: Optional["BotPit"] = None
 
 
-BINANCE_MARK = "https://fapi.binance.com/fapi/v1/premiumIndex"
-
-
-def get_mark_price(pair: str) -> float:
+def _mark_binance(pair: str) -> float:
     symbol = pair.replace("-", "")
     r = requests.get(BINANCE_MARK, params={"symbol": symbol}, timeout=5)
     r.raise_for_status()
     return float(r.json()["markPrice"])
+
+
+def _mark_bybit(pair: str) -> float:
+    symbol = pair.replace("-", "")
+    r = requests.get(BYBIT_TICKERS, params={"category": "linear", "symbol": symbol}, timeout=5)
+    r.raise_for_status()
+    data = r.json()
+    if data.get("retCode") != 0:
+        raise RuntimeError(f"Bybit ticker error {data.get('retCode')}: {data.get('retMsg')}")
+    lst = data["result"]["list"]
+    if not lst:
+        raise RuntimeError(f"Bybit ticker: no data for {symbol}")
+    t = lst[0]
+    return float(t.get("markPrice") or t["lastPrice"])
+
+
+def get_mark_price(pair: str) -> float:
+    try:
+        return _mark_binance(pair)
+    except Exception as e:
+        log.warning("Binance mark price failed (%s) — falling back to Bybit", e)
+        return _mark_bybit(pair)
 
 
 def watch_stops(snap: Snapshot, mark_price: float) -> Optional[Decision]:


### PR DESCRIPTION
Closes #32.

## Problem

`get_mark_price()` and `_fetch_candles()` both hit a single venue (`fapi.binance.com`). On a shared-NAT PaaS the egress IP's reputation with Binance is outside our control — a co-tenant hammering the same IP gets it `418`'d and the ban is inherited. The Stuber hit exactly this on today's deploy: ~8 min in the `network blip` retry loop (alive but blind to prices) until a `railway redeploy` landed on a clean IP. Flat at the time, so no damage — but a leveraged position open during such a window would be un-managed (the watcher needs a mark price to check stop/TP).

## Change — chained market-data sources

Each hop is on an independent IP-reputation surface:

1. **Binance USDⓈ-M futures** — primary; the right number (perp mark price), free, works most of the time
2. **FMP crypto feed** — used **iff `STUBER_FMP_KEY` is set**; a paid feed (same provider BotPit uses for the macro calendar), so a more reliable second hop than a free public API. Serves aggregated spot → a small basis vs. perp mark, acceptable for a degraded fallback. `v3/quote/{SYM}` for price, `v3/historical-chart/{interval}/{SYM}` for candles (newest-first; reversed; string dates parsed to epoch-ms best-effort). Symbol map: `BTC-USDT`→`BTCUSD` etc.
3. **Bybit linear perps** — last resort; free, no key. `v5/market/tickers` for mark price, `v5/market/kline` for candles (newest-first; reversed; interval codes mapped, e.g. `15m`→`15`, `4h`→`240`).

If **all configured sources** fail: unchanged behaviour — candle fetch falls back to the in-memory cache, mark-price failure falls through to the `run()` retry loop. No `STUBER_FMP_KEY` ⇒ the FMP hop is skipped; Bybit fallback works standalone. No strategy change. STRATEGY.md updated.

## Deploying

Once merged, needs a `railway up` from `submissions/the-stuber/` to go live (can be batched with the next deploy). To actually use FMP, also set `STUBER_FMP_KEY` in the Railway service env — without it the chain is just Binance → Bybit.

## Testing

`python3 -m py_compile` clean. Smoke-tested with a mocked `requests`:
- Binance 418 → falls to FMP (mark + candles, candles re-ordered oldest-first, dates parsed)
- Binance 418 + FMP 429 → falls to Bybit
- no `STUBER_FMP_KEY` → FMP hop skipped, straight Binance → Bybit
- unmapped timeframe on a fallback → clean `ValueError`, bubbles to the next hop

🤖 Generated with [Claude Code](https://claude.com/claude-code)